### PR TITLE
Only convert list to dict in special case of when list is list of 2 element tuples; otherwise chaos ensues.

### DIFF
--- a/objectifier/objectifier.py
+++ b/objectifier/objectifier.py
@@ -3,9 +3,9 @@ import json
 class Objectifier(object):
     def __init__(self, response_data):
         if type(response_data) == list:
-            try:
+            if self.is_list_of_2_element_tuples(response_data):
                 self.response_data = dict(response_data)
-            except:
+            else:
                 self.response_data = response_data
         else:
             try:
@@ -14,6 +14,16 @@ class Objectifier(object):
                 self.response_data = response_data
             except TypeError:
                 self.response_data = response_data
+
+    def is_list_of_2_element_tuples(self, input):
+        if not isinstance(input, list):
+            return False
+
+        for item in input:
+            if not isinstance(item, tuple) or len(item) != 2:
+                return False
+
+        return True
 
     @staticmethod
     def objectify_if_needed(response_data):


### PR DESCRIPTION
Fixes GH-3.

If I run the tests in #2 along with this change, I get:

```
marca@scml-marca:~/dev/git-repos/objectifier$ python setup.py test
running test
running egg_info
writing objectifier.egg-info/PKG-INFO
writing top-level names to objectifier.egg-info/top_level.txt
writing dependency_links to objectifier.egg-info/dependency_links.txt
reading manifest file 'objectifier.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'objectifier.egg-info/SOURCES.txt'
running build_ext
test_dict_1 (objectifier.tests.BasicTests) ... ok
test_dict_2 (objectifier.tests.BasicTests) ... ok
test_dict_3 (objectifier.tests.BasicTests) ... ok
test_json_1 (objectifier.tests.BasicTests) ... ok
test_json_2 (objectifier.tests.BasicTests) ... ok
test_list_of_dicts_1 (objectifier.tests.BasicTests) ... ok
test_list_of_dicts_2 (objectifier.tests.BasicTests) ... ok
test_list_of_ints (objectifier.tests.BasicTests) ... ok
test_list_of_strings (objectifier.tests.BasicTests) ... ok
test_list_of_tuples (objectifier.tests.BasicTests) ... ok
test_str_1 (objectifier.tests.BasicTests) ... ok
test_str_empty (objectifier.tests.BasicTests) ... ok
test_tuple_1 (objectifier.tests.BasicTests) ... ok
test_tuple_empty (objectifier.tests.BasicTests) ... ok
test_tuple_of_tuples (objectifier.tests.BasicTests) ... ok

----------------------------------------------------------------------
Ran 15 tests in 0.003s

OK
```
