### PR TITLE
Make compatible with Python 2.6

### DIFF
--- a/objectifier/objectifier.py
+++ b/objectifier/objectifier.py
@@ -4,6 +4,11 @@ try:
 except ImportError:
     import xml.etree.ElementTree as ElementTree
 
+# ElementTree in 2.7 raises ElementTree.ParseError; 2.6 raises SyntaxError
+try:
+    ElementTree.ParseError
+except AttributeError:
+    ElementTree.ParseError = SyntaxError
 
 def etree_list_items_all_have_same_tag(l):
     last_tag = None
@@ -87,11 +92,11 @@ class Objectifier(object):
 
     def __repr__(self):
         try:
-            return "<Objectifier#dict {}>".format(" ".join(["%s=%s" % (k, type(v).__name__)
+            return "<Objectifier#dict {0}>".format(" ".join(["%s=%s" % (k, type(v).__name__)
                 for k, v in self.response_data.iteritems()]))
         except AttributeError:
             try:
-                return "<Objectifier#list elements:{}>".format(len(self.response_data))
+                return "<Objectifier#list elements:{0}>".format(len(self.response_data))
             except TypeError:
                 return self.response_data
 


### PR DESCRIPTION
This PR makes objectifier work with Python 2.6. It solves two issues:
1. Older version of Python don't like `{}` in format strings - they want it to be numbered -- e.g.: `{0}`.
2. The `ElementTree` library in Python 2.6 doesn't define a `ParseError` exception (it uses `SyntaxError` instead).
