### PR TITLE
Add support for Python 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ python:
   - "2.7"
   - "3.2"
   - "pypy"
-script: python setup.py test
+before_script: pip install --use-mirrors nose .
+script: nosetests -v -w /tmp objectifier.tests

--- a/objectifier/tests.py
+++ b/objectifier/tests.py
@@ -36,13 +36,17 @@ class BasicTests(TestCase):
 
     def test_dict_1(self):
         obj = Objectifier({'a': 1, 'b': 2})
-        self.assertEqual(repr(obj), '<Objectifier#dict a=int b=int>')
+        self.assertTrue('<Objectifier#dict' in repr(obj))
+        self.assertTrue('a=int' in repr(obj))
+        self.assertTrue('b=int' in repr(obj))
         self.assertEqual(obj.a, 1)
         self.assertEqual(obj.b, 2)
 
     def test_dict_2(self):
         obj = Objectifier({'a': 1, 'b': 'c'})
-        self.assertEqual(repr(obj), '<Objectifier#dict a=int b=str>')
+        self.assertTrue('<Objectifier#dict' in repr(obj))
+        self.assertTrue('a=int' in repr(obj))
+        self.assertTrue('b=str' in repr(obj))
         self.assertEqual(obj.a, 1)
         self.assertEqual(obj.b, 'c')
 
@@ -54,7 +58,9 @@ class BasicTests(TestCase):
 
     def test_dict_3(self):
         obj = Objectifier({'a': 1, 'b': {'c': 2, 'd': {'e': [3, {'f': 4}]}}})
-        self.assertEqual(repr(obj), '<Objectifier#dict a=int b=dict>')
+        self.assertTrue('<Objectifier#dict' in repr(obj))
+        self.assertTrue('a=int' in repr(obj))
+        self.assertTrue('b=dict' in repr(obj))
         self.assertEqual(obj.a, 1)
         self.assertEqual(obj.b.c, 2)
         self.assertEqual(obj.b.d.e[0], 3)
@@ -88,7 +94,9 @@ class BasicTests(TestCase):
 
     def test_list_of_tuples(self):
         obj = Objectifier([('a', 1), ('b', 2)])
-        self.assertEqual(repr(obj), '<Objectifier#dict a=int b=int>')
+        self.assertTrue('<Objectifier#dict' in repr(obj))
+        self.assertTrue('a=int' in repr(obj))
+        self.assertTrue('b=int' in repr(obj))
         self.assertEqual(obj.a, 1)
         self.assertEqual(obj.b, 2)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-with open("README.rst") as file:
+with open(os.path.join(os.path.dirname(__file__), "README.rst")) as file:
     long_description = file.read()
 
 setup(
@@ -23,6 +23,7 @@ setup(
     author_email=metadata.__email__,
     packages=['objectifier'],
     test_suite='objectifier.tests',
+    use_2to3=True,
     package_data={'': ['LICENSE', 'README.rst']}
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py25, py26, py27, py30, py31, py32, pypy, jython
+envlist = py26, py27, py30, py31, py32, py33, pypy
 
 [testenv]
-commands = python setup.py test
+commands = nosetests -v -w /tmp objectifier.tests
+deps = nose
 
 [testenv:py25]
 deps = simplejson


### PR DESCRIPTION
Pretty easy, because instead of changing code, I simply rely on [distribute's `use_2to3` feature](http://packages.python.org/distribute/python3.html), which automatically translates from Python 2 to Python 3 at packaging/installation time. The trick is to make sure that the tests run against the translated code and not the untranslated code in the source directory -- this is why I use `nosetests`, because I know how to do this with `nosetests` in a cross-platform way and I'm not sure how to accomplish this with `unittest`'s test runner.

With this change and also the Python 2.6 changes in #6, I get this from Tox:

```
  py26: commands succeeded
  py27: commands succeeded
  py30: commands succeeded
  py31: commands succeeded
  py32: commands succeeded
  py33: commands succeeded
  pypy: commands succeeded
  congratulations :)
```

Passing Travis CI build: https://travis-ci.org/#!/msabramo/objectifier/builds/2919924
