### PR TITLE
Yaml support

### DIFF
--- a/objectifier/objectifier.py
+++ b/objectifier/objectifier.py
@@ -43,11 +43,21 @@ def arrayify_etree(tree):
 def arrayify_xml(xml_str):
     return arrayify_etree(ElementTree.fromstring(xml_str))
 
+def is_list_of_2_element_tuples(input):
+    if not isinstance(input, list):
+        return False
+
+    for item in input:
+        if not isinstance(item, tuple) or len(item) != 2:
+            return False
+
+    return True
+
 
 class Objectifier(object):
     def __init__(self, response_data):
         if type(response_data) == list:
-            if self.is_list_of_2_element_tuples(response_data):
+            if is_list_of_2_element_tuples(response_data):
                 self.response_data = dict(response_data)
             else:
                 self.response_data = response_data
@@ -65,15 +75,7 @@ class Objectifier(object):
             except TypeError:
                 self.response_data = response_data
 
-    def is_list_of_2_element_tuples(self, input):
-        if not isinstance(input, list):
-            return False
 
-        for item in input:
-            if not isinstance(item, tuple) or len(item) != 2:
-                return False
-
-        return True
 
     @staticmethod
     def _objectify_if_needed(response_data):

--- a/objectifier/objectifier.py
+++ b/objectifier/objectifier.py
@@ -53,6 +53,18 @@ def is_list_of_2_element_tuples(input):
 
     return True
 
+def parse_as_json(data):
+    try:
+        # Assume the data is JSON
+        return json.loads(data)
+    except ValueError:
+        return None
+
+def parse_as_xml(data):
+    try:
+        return arrayify_xml(data)
+    except ElementTree.ParseError:
+        return None
 
 class Objectifier(object):
     def __init__(self, response_data):
@@ -61,20 +73,19 @@ class Objectifier(object):
                 self.response_data = dict(response_data)
             else:
                 self.response_data = response_data
-        else:
-            try:
-                # Assume the data is JSON
-                self.response_data = json.loads(response_data)
-            except ValueError:
-                try:
-                    # A JSON object couldn't be found, so try to parse the data
-                    # as XML
-                    self.response_data = arrayify_xml(response_data)
-                except ElementTree.ParseError:
-                    self.response_data = response_data
-            except TypeError:
-                self.response_data = response_data
+            return
+        if self._try_parsing(response_data, parse_as_json):
+            return
+        if self._try_parsing(response_data, parse_as_xml):
+            return
+        self.response_data = response_data
 
+    def _try_parsing(self, data, parser_function):
+        try:
+            self.response_data = parser_function(data)
+        except:
+            return False
+        return self.response_data is not None
 
 
     @staticmethod

--- a/objectifier/objectifier.py
+++ b/objectifier/objectifier.py
@@ -68,6 +68,10 @@ def parse_as_xml(data):
 
 class Objectifier(object):
     def __init__(self, response_data):
+        # self.response_data = None
+        if type(response_data) == dict:
+            self.response_data = response_data
+            return
         if type(response_data) == list:
             if is_list_of_2_element_tuples(response_data):
                 self.response_data = dict(response_data)

--- a/objectifier/objectifier.py
+++ b/objectifier/objectifier.py
@@ -1,5 +1,12 @@
 import json
 
+# Import yaml if available
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
 try:
     import xml.etree.cElementTree as ElementTree
 except ImportError:
@@ -60,6 +67,14 @@ def parse_as_json(data):
     except ValueError:
         return None
 
+def parse_as_yaml(data):
+    if yaml is None:
+        return None
+    try:
+        return yaml.load(data)
+    except yaml.YAMLError:
+        return None
+
 def parse_as_xml(data):
     try:
         return arrayify_xml(data)
@@ -79,6 +94,8 @@ class Objectifier(object):
                 self.response_data = response_data
             return
         if self._try_parsing(response_data, parse_as_json):
+            return
+        if self._try_parsing(response_data, parse_as_yaml):
             return
         if self._try_parsing(response_data, parse_as_xml):
             return

--- a/objectifier/objectifier.py
+++ b/objectifier/objectifier.py
@@ -76,11 +76,11 @@ class Objectifier(object):
         return True
 
     @staticmethod
-    def objectify_if_needed(response_data):
+    def _objectify_if_needed(response_data):
         """
         Returns an objectifier object to wrap the provided response_data.
         """
-        if hasattr(response_data, 'pop'):
+        if hasattr(response_data, 'pop'): # In other words, if this is a list
             return Objectifier(response_data)
         return response_data
 
@@ -112,23 +112,23 @@ class Objectifier(object):
         """
         try:
             for k, v in self.response_data.iteritems():
-                yield (k, Objectifier.objectify_if_needed(v))
+                yield (k, Objectifier._objectify_if_needed(v))
         except AttributeError:
             try:
                 for i in self.response_data:
-                    yield Objectifier.objectify_if_needed(i)
+                    yield Objectifier._objectify_if_needed(i)
             except TypeError:
                 raise StopIteration
 
     def __getitem__(self, k):
         try:
-            return Objectifier.objectify_if_needed(self.response_data[k])
+            return Objectifier._objectify_if_needed(self.response_data[k])
         except TypeError:
             return None
 
     def __getattr__(self, k):
         if k in self.response_data:
-            return Objectifier.objectify_if_needed(self.response_data[k])
+            return Objectifier._objectify_if_needed(self.response_data[k])
         return None
 
 


### PR DESCRIPTION
I have added YAML parsing support and in the process done a bit of refactoring so that:
- I didn't have to further indent blocks in more nested try/except
- Tab completion for the Objectifier objects did not show internal methods, only the data

YAML parsing is conditional to the availability of a module called `yaml`
